### PR TITLE
fixing authentication second time for parent-children elections

### DIFF
--- a/authapi/authmethods/m_emailpwd.py
+++ b/authapi/authmethods/m_emailpwd.py
@@ -190,16 +190,12 @@ class EmailPWD:
             return self.authenticate_error("invalid-pipeline", req, auth_event)
 
         if mode == "authenticate":
-            if not verify_num_successful_logins(auth_event, 'OpenIdConnect', user, req):
+            if not verify_num_successful_logins(auth_event, 'EmailPWD', user, req):
                 return self.authenticate_error(
                     "invalid_num_successful_logins_allowed", req, auth_event
                 )
-            if (auth_event.num_successful_logins_allowed > 0 and
-                user.userdata.successful_logins.filter(is_active=True).count() >= auth_event.num_successful_logins_allowed):
-                return self.authenticate_error(
-                    "invalid_num_successful_logins_allowed", req, auth_event)
 
-            return return_auth_data('PWD', req, request, user, auth_event)
+            return return_auth_data('EmailPWD', req, request, user, auth_event)
 
         LOGGER.debug(\
             "EmailPWD.authenticate success\n"\


### PR DESCRIPTION
In `email-and-password` the verification if a voter has voted too many times was being done twice:
1. once using the new general function for it `verify_num_successful_logins`, which is the correct way.
2. another time using the old code that verified this, that didn't work for parent-children elections.

In this commit we solve this simply by removing the code for 2.