### PR TITLE
Fix upsert users

### DIFF
--- a/iam/api/management/commands/upsert_users.py
+++ b/iam/api/management/commands/upsert_users.py
@@ -169,7 +169,7 @@ class Command(BaseCommand):
                     ))
                     continue
                 else:
-                    db_user = User.objects.create_user(kwargs)
+                    db_user = User.objects.create_user(**kwargs)
             else:
                 if create_only:
                     print("Error: user with id %s does not exist" % user_id)


### PR DESCRIPTION
A recent change in the code introduced a bug for upserting users through the `config.yml`. This PR fixes the call to create the users by using the spread operator to pass the parameters.