### PR TITLE
Fix updating upsert users (6.1.x)

### DIFF
--- a/iam/api/management/commands/upsert_users.py
+++ b/iam/api/management/commands/upsert_users.py
@@ -188,8 +188,8 @@ class Command(BaseCommand):
                     db_user.email = user_data['email']
             
             db_user.is_active = user_data.get('is_active', False)
-            db_user.is_admin = user_data.get('is_admin', False)
-            db_user.is_staff = user_data.get('is_admin', False)
+            db_user.is_superuser = user_data.get('is_superuser', False)
+            db_user.is_staff = user_data.get('is_staff', False)
 
             # if password is set, update it
             if 'password' in user_data:


### PR DESCRIPTION
This is a mirror PR for version 6.1.x that was included on master on [this PR](https://github.com/sequentech/iam/pull/226). This is a follow-up [on a previous fix](https://github.com/sequentech/iam/pull/225) on the upsert users script. The part that updates users still had bug.