### PR TITLE
adding set-public-candidates support

### DIFF
--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -756,7 +756,7 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
     auth_event = get_object_or_404(AuthEvent, pk=auth_event_id)
 
     # if this auth event has children, update also them
-    if parent_auth_event is None:
+    if parent_auth_event_id is None:
         parent_auth_event = auth_event
     else:
       parent_auth_event = get_object_or_404(AuthEvent, pk=parent_auth_event_id)
@@ -869,7 +869,7 @@ def set_public_candidates_task(
     auth_event = get_object_or_404(AuthEvent, pk=auth_event_id)
 
     # if this auth event has children, update also them
-    if parent_auth_event is None:
+    if parent_auth_event_id is None:
         parent_auth_event = auth_event
     else:
       parent_auth_event = get_object_or_404(AuthEvent, pk=parent_auth_event_id)

--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -656,7 +656,7 @@ def publish_results_task(user_id, auth_event_id, visit_children, parent_auth_eve
     if auth_event.children_election_info is not None and visit_children:
         for child_id in auth_event.children_election_info['natural_order']:
             publish_results_task.apply_async(
-                args=[user_id, child_id, True, parent_auth_event_id]
+                args=[user_id, child_id, True, auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -764,7 +764,7 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             unpublish_results_task.apply_async(
-                args=[user_id, child_id, parent_auth_event_id]
+                args=[user_id, child_id, auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -877,7 +877,7 @@ def set_public_candidates_task(
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             set_public_candidates_task.apply_async(
-                args=[user_id, child_id, make_public, parent_auth_event_id]
+                args=[user_id, child_id, make_public, auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -992,7 +992,7 @@ def allow_tally_task(user_id, auth_event_id, parent_auth_event_id=None):
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             allow_tally_task.apply_async(
-                args=[user_id, child_id, parent_auth_event_id]
+                args=[user_id, child_id, auth_event_id]
             )
 
     # A.2 call to ballot-box

--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -764,7 +764,7 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             unpublish_results_task.apply_async(
-                args=[user_id, child_id, parent_auth_event]
+                args=[user_id, child_id, parent_auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -877,7 +877,7 @@ def set_public_candidates_task(
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             set_public_candidates_task.apply_async(
-                args=[user_id, child_id, make_public, parent_auth_event]
+                args=[user_id, child_id, make_public, parent_auth_event_id]
             )
 
     # A.2 call to ballot-box

--- a/iam/api/urls.py
+++ b/iam/api/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'^auth-event/(?P<pk>\d+)/calculate-results/$', views.calculate_results, name='calculate-results'),
     url(r'^auth-event/(?P<pk>\d+)/publish-results/$', views.publish_results, name='publish-results'),
     url(r'^auth-event/(?P<pk>\d+)/unpublish-results/$', views.unpublish_results, name='unpublish-results'),
+    url(r'^auth-event/(?P<pk>\d+)/set-public-candidates/$', views.set_public_candidates, name='set-public-candidates'),
     url(r'^auth-event/(?P<pk>\d+)/archive/$', views.archive, name='archive'),
     url(r'^auth-event/(?P<pk>\d+)/unarchive/$', views.unarchive, name='unarchive'),
     url(r'^auth-event/(?P<pk>\d+)/callback/$', views.callback, name='callback'),


### PR DESCRIPTION
Creating a task that can set the public candidates for an election and
all the children elections, and logs this in the activity log.