### PR TITLE
adding set-public-candidates support

### DIFF
--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -656,7 +656,7 @@ def publish_results_task(user_id, auth_event_id, visit_children, parent_auth_eve
     if auth_event.children_election_info is not None and visit_children:
         for child_id in auth_event.children_election_info['natural_order']:
             publish_results_task.apply_async(
-                args=[user_id, child_id, True, parent_auth_event_id]
+                args=[user_id, child_id, True, auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -756,7 +756,7 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
     auth_event = get_object_or_404(AuthEvent, pk=auth_event_id)
 
     # if this auth event has children, update also them
-    if parent_auth_event is None:
+    if parent_auth_event_id is None:
         parent_auth_event = auth_event
     else:
       parent_auth_event = get_object_or_404(AuthEvent, pk=parent_auth_event_id)
@@ -764,7 +764,7 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             unpublish_results_task.apply_async(
-                args=[user_id, child_id, parent_auth_event]
+                args=[user_id, child_id, auth_event_id]
             )
 
     # A.2 call to ballot-box
@@ -844,6 +844,125 @@ def unpublish_results_task(user_id, auth_event_id, parent_auth_event_id=None):
         )
         action.save()
 
+
+@shared_task(name='api.tasks.set_public_candidates')
+def set_public_candidates_task(
+    user_id,
+    auth_event_id,
+    make_public,
+    parent_auth_event_id=None
+):
+    '''
+    Launches the unpublish results ballot-box call in a task.
+    If the election has children, also launches the call for
+    those.
+    '''
+    logger.info(
+        '\n\nset_public_candidates_task(user_id=%r, auth_event_id=%r, make_public=%r,parent_auth_event_id=%r)' % (
+            user_id,
+            auth_event_id,
+            make_public,
+            parent_auth_event_id
+        )
+    )
+    user = get_object_or_404(User, pk=user_id)
+    auth_event = get_object_or_404(AuthEvent, pk=auth_event_id)
+
+    # if this auth event has children, update also them
+    if parent_auth_event_id is None:
+        parent_auth_event = auth_event
+    else:
+      parent_auth_event = get_object_or_404(AuthEvent, pk=parent_auth_event_id)
+
+    if auth_event.children_election_info is not None:
+        for child_id in auth_event.children_election_info['natural_order']:
+            set_public_candidates_task.apply_async(
+                args=[user_id, child_id, make_public, auth_event_id]
+            )
+
+    # A.2 call to ballot-box
+    for callback_base in settings.SEQUENT_ELECTIONS_BASE:
+        callback_url = "%s/api/election/%s/set-public-candidates" % (
+            callback_base,
+            auth_event_id
+        )
+        data = {
+            "publicCandidates": make_public
+        }
+
+        req = requests.post(
+            callback_url,
+            json=data,
+            headers={
+                'Authorization': genhmac(
+                    settings.SHARED_SECRET,
+                    "1:AuthEvent:%s:set-public-candidates" % auth_event_id
+                ),
+                'Content-type': 'application/json'
+            }
+        )
+        if req.status_code != 200:
+            logger.error(
+                "set_public_candidates_task(user_id=%r, auth_event_id=%r,make_public=%r,parent_auth_event_id=%r): post\n"\
+                "ballot_box.callback_url '%r'\n"\
+                "ballot_box.data '%r'\n"\
+                "ballot_box.status_code '%r'\n"\
+                "ballot_box.text '%r'\n",\
+                user_id,
+                auth_event_id,
+                make_public,
+                parent_auth_event_id,
+                callback_url,
+                data,
+                req.status_code,
+                req.text
+            )
+
+            # log the action
+            action = Action(
+                executer=user,
+                receiver=None,
+                action_name='authevent:set-public-candidates:error',
+                event=parent_auth_event,
+                metadata=dict(
+                    auth_event=auth_event.pk,
+                    make_public=make_public,
+                    request_status_code=req.status_code,
+                    request_text=req.text
+                )
+            )
+            action.save()
+            return
+
+        logger.info(
+            "publish_results_task(user_id=%r, auth_event_id=%r,make_public=%r,parent_auth_event_id=%r): post\n"\
+            "ballot_box.callback_url '%r'\n"\
+            "ballot_box.data '%r'\n"\
+            "ballot_box.status_code '%r'\n"\
+            "ballot_box.text '%r'\n",\
+            user_id,
+            auth_event_id,
+            make_public,
+            parent_auth_event_id,
+            callback_url,
+            data,
+            req.status_code,
+            req.text
+        )
+
+        # log the action
+        action = Action(
+            executer=user,
+            receiver=None,
+            action_name='authevent:set-public-candidates:success',
+            event=parent_auth_event,
+            metadata=dict(
+                auth_event=auth_event.pk,
+                make_public=make_public
+            )
+        )
+        action.save()
+
 @shared_task(name='api.tasks.allow_tally')
 def allow_tally_task(user_id, auth_event_id, parent_auth_event_id=None):
     '''
@@ -873,7 +992,7 @@ def allow_tally_task(user_id, auth_event_id, parent_auth_event_id=None):
     if auth_event.children_election_info is not None:
         for child_id in auth_event.children_election_info['natural_order']:
             allow_tally_task.apply_async(
-                args=[user_id, child_id, parent_auth_event_id]
+                args=[user_id, child_id, auth_event_id]
             )
 
     # A.2 call to ballot-box

--- a/iam/api/urls.py
+++ b/iam/api/urls.py
@@ -32,6 +32,7 @@ urlpatterns = [
     url(r'^auth-event/(?P<pk>\d+)/calculate-results/$', views.calculate_results, name='calculate-results'),
     url(r'^auth-event/(?P<pk>\d+)/publish-results/$', views.publish_results, name='publish-results'),
     url(r'^auth-event/(?P<pk>\d+)/unpublish-results/$', views.unpublish_results, name='unpublish-results'),
+    url(r'^auth-event/(?P<pk>\d+)/set-public-candidates/$', views.set_public_candidates, name='set-public-candidates'),
     url(r'^auth-event/(?P<pk>\d+)/archive/$', views.archive, name='archive'),
     url(r'^auth-event/(?P<pk>\d+)/unarchive/$', views.unarchive, name='unarchive'),
     url(r'^auth-event/(?P<pk>\d+)/callback/$', views.callback, name='callback'),


### PR DESCRIPTION
* adding set-public-candidates support

Creating a task that can set the public candidates for an election and
all the children elections, and logs this in the activity log.

* typo fixes

* fix typo 2

* setting parent correctly in recursive calls