### PR TITLE
Support HTML format when sending email auth-codes

### DIFF
--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -1059,6 +1059,23 @@ ae_email_config.update( {
     }
 })
 
+ae_email_config_html = ae_email_default.copy()
+ae_email_config_html.update( {
+    "auth_method_config": {
+        "authentication-action":{
+            "mode":"vote",
+            "mode-config": None
+        },
+        "registration-action":{
+            "mode":"vote",
+            "mode-config":None
+        },
+        "subject": "Vote",
+        "msg": "Enter in __URL__ and put this code __CODE__",
+        "html_message": "<html><head></head><body>HTML Click __URL__ and put this code __CODE__</body></html>",
+    }
+})
+
 ae_email_config_incorrect1 = ae_email_config.copy()
 ae_email_config_incorrect1.update({"config": {"aaaaaa": "bbbb"}})
 

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -214,14 +214,14 @@ class ApiTestHtmlEmail(TestCase):
         self.assertEqual(response.status_code, 200)
         return c.post('/api/auth-event/', authevent)
 
-    def test_add_census_authevent_email_default(self):
+    def test_add_census_authevent_email_default(self, aeid):
         c = JClient()
-        response = c.authenticate(self.aeid, test_data.auth_email_default)
+        response = c.authenticate(aeid, test_data.auth_email_default)
         self.assertEqual(response.status_code, 200)
 
-        response = c.census(self.aeid, test_data.census_email_default)
+        response = c.census(aeid, test_data.census_email_default)
         self.assertEqual(response.status_code, 200)
-        response = c.get('/api/auth-event/%d/census/' % self.aeid, {})
+        response = c.get('/api/auth-event/%d/census/' % aeid, {})
         self.assertEqual(response.status_code, 200)
         r = parse_json_response(response)
         self.assertEqual(len(r['object_list']), 4)
@@ -237,10 +237,9 @@ class ApiTestHtmlEmail(TestCase):
         ae = AuthEvent.objects.last()
         self.assertEqual(ae.auth_method_config['config']['html_message'], data['auth_method_config']['html_message'])
 
-        self.ae = ae
-        self.aeid = ae.pk
+        aeid = ae.pk
 
-        self.test_add_census_authevent_email_default() # Add census
+        self.test_add_census_authevent_email_default(aeid) # Add census
         correct_tpl = {
             "subject": "Vote",
             "msg": "this is an example __CODE__ and __URL__",
@@ -251,21 +250,21 @@ class ApiTestHtmlEmail(TestCase):
         c = JClient()
         response = c.authenticate(self.aeid_special, self.admin_auth_data)
         self.assertEqual(response.status_code, 200)
-        response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, {})
+        response = c.post('/api/auth-event/%d/census/send_auth/' % aeid, {})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 4)
         msg_log = MsgLog.objects.all().last().msg
         self.assertEqual(msg_log.get('subject'), 'Confirm your email - Sequent')
         self.assertTrue(msg_log.get('msg').count(' -- Sequent https://sequentech.io'))
 
-        response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, correct_tpl)
+        response = c.post('/api/auth-event/%d/census/send_auth/' % aeid, correct_tpl)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 4*2)
         msg_log = MsgLog.objects.all().last().msg
         self.assertEqual(msg_log.get('subject'), correct_tpl.get('subject') + ' - Sequent')
         self.assertTrue(msg_log.get('msg').count('this is an example'))
 
-        response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, incorrect_tpl)
+        response = c.post('/api/auth-event/%d/census/send_auth/' % aeid, incorrect_tpl)
         self.assertEqual(response.status_code, 400)
 
 class ApiTestCreateNotReal(TestCase):

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -237,6 +237,12 @@ class ApiTestHtmlEmail(TestCase):
         ae = AuthEvent.objects.last()
         self.assertEqual(ae.auth_method_config['config']['html_message'], data['auth_method_config']['html_message'])
 
+        response = self.create_authevent(test_data.ae_email_config)
+        self.assertEqual(response.status_code, 200)
+        ae2 = AuthEvent.objects.last()
+        self.assertFalse(ae2.id == ae.id)     
+        self.assertFalse('html_message' in ae2.auth_method_config['config'])        
+
         aeid = ae.pk
 
         self.add_census(aeid) # Add census

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -2161,6 +2161,8 @@ class CensusSendAuth(View):
             config = {}
             if req.get('msg', ''):
                 config['msg'] = req.get('msg', '')
+            if req.get('html_message', ''):
+                config['html_message'] = req.get('html_message', '')
             if req.get('subject', ''):
                 config['subject'] = req.get('subject', '')
         else:

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -2161,7 +2161,7 @@ class CensusSendAuth(View):
             config = {}
             if req.get('msg', ''):
                 config['msg'] = req.get('msg', '')
-            if req.get('html_message', ''):
+            if req.get('html_message', None):
                 config['html_message'] = req.get('html_message', '')
             if req.get('subject', ''):
                 config['subject'] = req.get('subject', '')

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -1566,10 +1566,11 @@ class AuthEventView(View):
             if msg:
                 return json_response(status=400, message=msg)
 
-            auth_method_config = {
+            from copy import deepcopy
+            auth_method_config = deepcopy({
                     "config": METHODS.get(auth_method).CONFIG,
                     "pipeline": METHODS.get(auth_method).PIPELINES
-            }
+            })
             config = req.get('auth_method_config', None)
             if config:
                 msg += check_config(config, auth_method)
@@ -2180,6 +2181,12 @@ class CensusSendAuth(View):
 
         if config.get('msg', None) is not None:
             if type(config.get('msg', '')) != str or len(config.get('msg', '')) > settings.MAX_AUTH_MSG_SIZE[e.auth_method]:
+                return json_response(
+                    status=400,
+                    error_codename=ErrorCodes.BAD_REQUEST)
+
+        if config.get('html_message', None) is not None:
+            if type(config.get('html_message', '')) != str or len(config.get('html_message', '')) > settings.MAX_AUTH_MSG_SIZE[e.auth_method]:
                 return json_response(
                     status=400,
                     error_codename=ErrorCodes.BAD_REQUEST)

--- a/iam/authmethods/m_email.py
+++ b/iam/authmethods/m_email.py
@@ -144,10 +144,15 @@ class Email:
       {
         'check': 'index-check-list',
         'index': 'html_message',
+        'optional': True,
         'check-list': [
           {
-            'check': 'lambda',
-            'lambda': lambda x: (x is None) or ((isinstance(x, str) and len(x) > 0 and len(x) < 5000))
+            'check': 'isinstance',
+            'type': str
+          },
+          {
+            'check': 'length',
+            'range': [1, 5000]
           }
         ]
       },

--- a/iam/authmethods/m_email.py
+++ b/iam/authmethods/m_email.py
@@ -146,12 +146,8 @@ class Email:
         'index': 'html_message',
         'check-list': [
           {
-            'check': 'isinstance',
-            'type': str
-          },
-          {
-            'check': 'length',
-            'range': [1, 5000]
+            'check': 'lambda',
+            'lambda': lambda x: (x is None) or ((isinstance(x, str) and len(x) > 0 and len(x) < 5000))
           }
         ]
       },

--- a/iam/authmethods/m_email.py
+++ b/iam/authmethods/m_email.py
@@ -143,6 +143,20 @@ class Email:
       },
       {
         'check': 'index-check-list',
+        'index': 'html_message',
+        'check-list': [
+          {
+            'check': 'isinstance',
+            'type': str
+          },
+          {
+            'check': 'length',
+            'range': [1, 5000]
+          }
+        ]
+      },
+      {
+        'check': 'index-check-list',
         'index': 'subject',
         'check-list': [
           {

--- a/iam/authmethods/m_email_otp.py
+++ b/iam/authmethods/m_email_otp.py
@@ -147,6 +147,21 @@ class EmailOtp:
       },
       {
         'check': 'index-check-list',
+        'index': 'html_message',
+        'optional': True,
+        'check-list': [
+          {
+            'check': 'isinstance',
+            'type': str
+          },
+          {
+            'check': 'length',
+            'range': [1, 5000]
+          }
+        ]
+      },
+      {
+        'check': 'index-check-list',
         'index': 'subject',
         'check-list': [
           {

--- a/iam/authmethods/m_sms.py
+++ b/iam/authmethods/m_sms.py
@@ -154,6 +154,21 @@ class Sms:
       },
       {
         'check': 'index-check-list',
+        'index': 'html_message',
+        'optional': True,
+        'check-list': [
+          {
+            'check': 'isinstance',
+            'type': str
+          },
+          {
+            'check': 'length',
+            'range': [1, 5000]
+          }
+        ]
+      },
+      {
+        'check': 'index-check-list',
         'index': 'registration-action',
         'check-list': [
           {

--- a/iam/authmethods/m_sms_otp.py
+++ b/iam/authmethods/m_sms_otp.py
@@ -155,6 +155,21 @@ class SmsOtp:
       },
       {
         'check': 'index-check-list',
+        'index': 'html_message',
+        'optional': True,
+        'check-list': [
+          {
+            'check': 'isinstance',
+            'type': str
+          },
+          {
+            'check': 'length',
+            'range': [1, 5000]
+          }
+        ]
+      },
+      {
+        'check': 'index-check-list',
         'index': 'registration-action',
         'check-list': [
           {

--- a/iam/contracts/base.py
+++ b/iam/contracts/base.py
@@ -166,7 +166,15 @@ def check_index_check_list(contract, data):
           {"index": 1, "check-list": [{"check:" "isinstance", "type": str}]},
           ["a", 1, 5.6])
     '''
-    check_list(contract['check-list'], data[contract['index']])
+    index = contract['index']
+    if not contract.get('optional') and index not in data:
+            raise CheckException(
+                key="index-not-found",
+                context={
+                    "contract":contract,
+                    "data":data})
+    if index in data:
+        check_list(contract['check-list'], data[index])
 
 def check_dict_keys_exist(contract, data):
     '''

--- a/iam/iam/settings.py
+++ b/iam/iam/settings.py
@@ -74,6 +74,8 @@ ALLOW_ADMIN_AUTH_REGISTRATION = False
 
 ALLOW_DEREGISTER = True
 
+ALLOW_HTML_EMAILS = False
+
 AWS_SNS_MESSAGE_ATTRIBUTES = {}
 
 # If this option is true, when an user tries to register and the user is

--- a/iam/iam/test_settings.py
+++ b/iam/iam/test_settings.py
@@ -69,6 +69,8 @@ TIME_ZONE = 'Europe/Madrid'
 
 ALLOW_DEREGISTER = True
 
+ALLOW_HTML_EMAILS = True
+
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 

--- a/iam/utils.py
+++ b/iam/utils.py
@@ -33,7 +33,7 @@ from django.core.validators import URLValidator
 from django.core.exceptions import ValidationError
 from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
-from django.core.mail import send_mail, EmailMessage
+from django.core.mail import send_mail, EmailMessage, EmailMultiAlternatives
 from django.core.paginator import Paginator
 from django.conf import settings
 from django.http import HttpResponse
@@ -430,6 +430,7 @@ def send_email_code(
     auth_event = user.userdata.event
     message_body = templates['message_body']
     message_subject= templates['message_subject']
+    message_html = templates['message_html']
 
     base_home_url = settings.HOME_URL
     home_url = template_replace_data(
@@ -488,13 +489,21 @@ def send_email_code(
         template_dict
     )
 
+    if message_html:
+        message_html = template_replace_data(
+            message_html,
+            template_dict
+        )
+
+
     # store the message log in the DB
     db_message_log = MsgLog(
         authevent_id=auth_event.id,
         receiver=receiver,
         msg=dict(
             subject=message_subject,
-            msg=message_body
+            msg=message_body,
+            html_message=message_html
         )
     )
     db_message_log.save()
@@ -512,15 +521,17 @@ def send_email_code(
     if acl:
         headers['Reply-To'] = acl.user.user.email
 
-    # TODO: Allow HTML messages for emails
-    email = EmailMessage(
+    email = EmailMultiAlternatives(
         message_subject,
         message_body,
         settings.DEFAULT_FROM_EMAIL,
         [receiver],
         headers=headers,
     )
+    if message_html:
+        email.attach_alternative(message_html, 'text/html')
     send_email(email)
+    
     db_message = Message(
         tlf=receiver[:20],
         ip=ip_address[:15],
@@ -693,6 +704,7 @@ def send_code(
                 method="email",
                 templates=dict(
                     message_body=base_config.get('msg'),
+                    message_html=base_config.get('html_message'),
                     message_subject=base_config.get('subject')
                 )
             ))

--- a/iam/utils.py
+++ b/iam/utils.py
@@ -489,6 +489,8 @@ def send_email_code(
         template_dict
     )
 
+    message_html = message_html if settings.ALLOW_HTML_EMAILS else None
+
     if message_html:
         message_html = template_replace_data(
             message_html,

--- a/iam/utils.py
+++ b/iam/utils.py
@@ -430,7 +430,7 @@ def send_email_code(
     auth_event = user.userdata.event
     message_body = templates['message_body']
     message_subject= templates['message_subject']
-    message_html = templates['message_html']
+    message_html = templates.get('message_html')
 
     base_home_url = settings.HOME_URL
     home_url = template_replace_data(


### PR DESCRIPTION
# Changes

  * Add an extra field `html_message` to the auth-event config, next to the [`msg` field](https://sequentech.github.io/documentation/docs/general/reference/election-creation-json#census-config-msg), along with corresponding unit tests. If html_message is empty or null, then it's not used.
  * Add an extra field `html_message` to the IAM CensusSendAuth view, next to the `msg` field, along with corresponding unit tests.
  * Add an IAM settings field `ALLOW_HTML_EMAILS` to enable this feature.
  * Fix issue when creating an election that could modify an auth method settings.
  * Add an `optional` field to contracts.