### PR TITLE
Support sending reminders to voters who didn't cast a vote

### DIFF
--- a/iam/api/models.py
+++ b/iam/api/models.py
@@ -25,7 +25,7 @@ from jsonfield import JSONField
 
 from django.dispatch import receiver
 from django.db.models.signals import post_save
-from django.db.models import Q, Count
+from django.db.models import Q
 from django.conf import settings
 from utils import genhmac
 from django.utils import timezone
@@ -372,7 +372,6 @@ class AuthEvent(models.Model):
             'auth_method': self.auth_method,
             'census': self.census,
             'users': self.len_census(),
-            'voted': self.len_voted_census(),
             'has_ballot_boxes': self.has_ballot_boxes,
             'tally_status': self.tally_status,
             'allow_public_census_query': self.allow_public_census_query,
@@ -511,14 +510,6 @@ class AuthEvent(models.Model):
 
     def len_census(self):
         return self.get_census_query().count()
-
-    def len_voted_census(self):
-        return self.get_census_query()\
-            .annotate(
-                logins=Count('user__successful_logins')
-            )\
-            .filter(logins__gt=0)\
-            .count()
 
     def autofill_fields(self, from_user=None, to_user=None):
         if not from_user or not to_user:

--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -65,7 +65,7 @@ def census_send_auth_task(
     census = []
     if userids is None:
         new_census = ACL.objects.filter(perm="vote", object_type="AuthEvent", object_id=str(pk))
-        filter = config.get('filter', None)
+        filter =  config.get('filter', None) if isinstance(config, dict) else None
         if filter is not None:
             if 'voted' == filter:
                 new_census = new_census\

--- a/iam/api/tasks.py
+++ b/iam/api/tasks.py
@@ -65,6 +65,20 @@ def census_send_auth_task(
     census = []
     if userids is None:
         new_census = ACL.objects.filter(perm="vote", object_type="AuthEvent", object_id=str(pk))
+        filter = config.get('filter', None)
+        if filter is not None:
+            if 'voted' == filter:
+                new_census = new_census\
+                    .annotate(
+                        logins=Count('user__successful_logins')
+                    )\
+                    .filter(logins__gt=0)
+            elif 'not_voted' == filter:
+                new_census = new_census\
+                    .annotate(
+                        logins=Count('user__successful_logins')
+                    )\
+                    .filter(logins__exact=0)
     else:
         users = User.objects.filter(id__in=userids)
         userdata = UserData.objects.filter(user__in=users)

--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -848,6 +848,14 @@ auth_sms_fields = {
         "code": "123456"
 }
 
+send_auth_filter_fields = {
+    "msg": "Vote in __URL__ with code __CODE__",
+    "subject": "Test Vote now with Sequent Tech Inc.",
+    "user-ids": None,
+    "auth-method": "email",
+    "filter": "voted"
+}
+
 # Authmethod config
 pipe_total_max_ip =  8
 pipe_total_max_tlf = 4

--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -848,12 +848,19 @@ auth_sms_fields = {
         "code": "123456"
 }
 
-send_auth_filter_fields = {
+send_auth_email_filter_fields = {
     "msg": "Vote in __URL__ with code __CODE__",
     "subject": "Test Vote now with Sequent Tech Inc.",
     "user-ids": None,
     "auth-method": "email",
     "filter": "voted"
+}
+
+send_auth_sms_filter_fields = {
+    "msg": "Vote in __URL__ with code __CODE__",
+    "user-ids": None,
+    "auth-method": "sms",
+    "filter":" voted"
 }
 
 # Authmethod config

--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -857,10 +857,10 @@ send_auth_email_filter_fields = {
 }
 
 send_auth_sms_filter_fields = {
-    "msg": "Vote in __URL__ with code __CODE__",
+    "msg": "Test Vote now with Sequent Tech Inc.",
     "user-ids": None,
     "auth-method": "sms",
-    "filter":" voted"
+    "filter": "voted"
 }
 
 # Authmethod config

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1379,10 +1379,23 @@ class TestFilterSendAuth(TestCase):
         c.save()
         self.code = c
 
+    def add_census_authevent_email_default(self):
+        c = JClient()
+        response = c.authenticate(self.aeid, test_data.auth_email_default)
+        self.assertEqual(response.status_code, 200)
+
+        response = c.census(self.aeid, test_data.census_email_default)
+        self.assertEqual(response.status_code, 200)
+        response = c.get('/api/auth-event/%d/census/' % self.aeid, {})
+        self.assertEqual(response.status_code, 200)
+        r = parse_json_response(response)
+        self.assertEqual(len(r['object_list']), 4)
+
     @override_settings(CELERY_ALWAYS_EAGER=True)
     def test_register_and_resend_code(self):
+        self.add_census_authevent_email_default()
         c = JClient()
-        response = c.register(self.aeid, test_data.register_email_default)
+        response = c.authenticate(self.aeid, test_data.auth_email_default)
         self.assertEqual(response.status_code, 200)
 
         data = test_data.send_auth_filter_fields.copy()

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1349,23 +1349,23 @@ class TestFilterSendAuth(TestCase):
         self.uid_admin = u_admin.id
 
         acl = ACL(
-            user=u_admin.userdata,
+            user=u_admin.userdata, 
             object_type='AuthEvent',
             perm='edit',
             object_id=self.aeid
         )
         acl.save()
-        self.add_census_authevent_email_default()
 
-        u = self.new_user('test', test_data.auth_email_default['email'], ae)
-        # register vote
-        self.add_vote(u, datetime(2010, 10, 10, 0, 30, 30, 0, None), ae)
+        u = User(username='test', email=test_data.auth_email_default['email'])
+        u.save()
+        u.userdata.event = ae
+        u.userdata.save()
         self.u = u.userdata
         self.uid = u.id
 
         acl = ACL(
             user=u.userdata,
-            object_type='AuthEvent',
+            object_type='AuthEvent', 
             perm='edit',
             object_id=self.aeid
         )

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1451,6 +1451,12 @@ class TestFilterSendAuthEmail(TestCase):
         msg_log = MsgLog.objects.all().last().msg
         self.assertEqual(msg_log.get('subject'), 'Test Vote now with Sequent Tech Inc. - Sequent')
 
+        data['filter'] = 'error'
+
+        # send message to those that haven't voted yet
+        response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, data)
+        self.assertEqual(response.status_code, 400)
+
 class TestFilterSendAuthSms(TestCase):
     def setUpTestData():
         flush_db_load_fixture()
@@ -1550,6 +1556,12 @@ class TestFilterSendAuthSms(TestCase):
         self.assertEqual(MsgLog.objects.count(), 4)
         msg_log = MsgLog.objects.all().last().msg
         self.assertEqual(msg_log.get('msg'), 'Test Vote now with Sequent Tech Inc. -- Sequent')
+
+        data['filter'] = 'error'
+
+        # send message to those that haven't voted yet
+        response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, data)
+        self.assertEqual(response.status_code, 400)
 
 class TestRegisterAndAuthenticateEmail(TestCase):
     def setUpTestData():

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1540,7 +1540,7 @@ class TestFilterSendAuthSms(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 1)
         msg_log = MsgLog.objects.all().last().msg
-        self.assertEqual(msg_log.get('subject'), 'Test Vote now with Sequent Tech Inc. - Sequent')
+        self.assertEqual(msg_log.get('msg'), 'Test Vote now with Sequent Tech Inc. -- Sequent')
 
         data['filter'] = 'not_voted'
 
@@ -1549,7 +1549,7 @@ class TestFilterSendAuthSms(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 4)
         msg_log = MsgLog.objects.all().last().msg
-        self.assertEqual(msg_log.get('subject'), 'Test Vote now with Sequent Tech Inc. - Sequent')
+        self.assertEqual(msg_log.get('msg'), 'Test Vote now with Sequent Tech Inc. -- Sequent')
 
 class TestRegisterAndAuthenticateEmail(TestCase):
     def setUpTestData():

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1314,7 +1314,7 @@ class TestExtraFields(TestCase):
         response = c.census(self.ae.pk, test_data.census_date_field_nok)
         self.assertEqual(response.status_code, 400)
 
-class TestFilterSendAuth(TestCase):
+class TestFilterSendAuthEmail(TestCase):
     def setUpTestData():
         flush_db_load_fixture()
 
@@ -1509,19 +1509,21 @@ class TestFilterSendAuth(TestCase):
 
         data = test_data.send_auth_filter_fields.copy()
 
+        # send message to all those that have voted
         response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 1)
         msg_log = MsgLog.objects.all().last().msg
-        self.assertEqual(msg_log.get('subject'), data.get('subject'))
+        self.assertEqual(msg_log.get('subject'), 'Test Vote now with Sequent Tech Inc. - Sequent')
 
         data['filter'] = 'not_voted'
 
+        # send message to those that haven't voted yet
         response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, data)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(MsgLog.objects.count(), 4)
         msg_log = MsgLog.objects.all().last().msg
-        self.assertEqual(msg_log.get('subject'), data.get('subject'))
+        self.assertEqual(msg_log.get('subject'), 'Test Vote now with Sequent Tech Inc. - Sequent')
 
 
 class TestRegisterAndAuthenticateEmail(TestCase):

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1470,7 +1470,7 @@ class TestFilterSendAuth(TestCase):
         r = parse_json_response(response)
         self.assertEqual(response.status_code, 200)
 
-    def test_add_census_authevent_email_default(self):
+    def add_census_authevent_email_default(self):
         c = JClient()
         response = c.authenticate(self.aeid, test_data.auth_email_default)
         self.assertEqual(response.status_code, 200)
@@ -1481,9 +1481,28 @@ class TestFilterSendAuth(TestCase):
         self.assertEqual(response.status_code, 200)
         r = parse_json_response(response)
         self.assertEqual(len(r['object_list']), 4)
+        return r['object_list']
 
-    #@override_settings(CELERY_ALWAYS_EAGER=True)
-    def FOO_test_register_and_resend_code(self):
+    def add_vote(self, user, date, auth_event):
+        vote = SuccessfulLogin(
+            created=date,
+            user=user.userdata,
+            auth_event=auth_event
+        )
+        vote.save()
+        return vote
+
+    @override_settings(CELERY_ALWAYS_EAGER=True)
+    def test_register_and_resend_code(self):
+        # add census
+        users = self.add_census_authevent_email_default()
+
+        # add vote
+        user1 = User.objects.get(id=users[0]["id"])
+        date = datetime(2010, 10, 10, 0, 30, 30, 0, None)
+        self.add_vote(user1, date, self.ae)
+
+        # authenticate
         c = JClient()
         response = c.authenticate(self.aeid, test_data.auth_email_default)
         self.assertEqual(response.status_code, 200)

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -2166,6 +2166,8 @@ class CensusSendAuth(View):
                 config['html_message'] = req.get('html_message', '')
             if req.get('subject', ''):
                 config['subject'] = req.get('subject', '')
+            if req.get('filter', None):
+                config['filter'] = req.get('filter', None)
         else:
             send_error = census_send_auth_task(
                 pk,
@@ -2187,6 +2189,12 @@ class CensusSendAuth(View):
 
         if config.get('html_message', None) is not None:
             if type(config.get('html_message', '')) != str or len(config.get('html_message', '')) > settings.MAX_AUTH_MSG_SIZE[e.auth_method]:
+                return json_response(
+                    status=400,
+                    error_codename=ErrorCodes.BAD_REQUEST)
+
+        if config.get('filter', None) is not None:
+            if type(config.get('filter', None)) != str or config.get('filter', None) not in ['voted', 'not_voted']:
                 return json_response(
                     status=400,
                     error_codename=ErrorCodes.BAD_REQUEST)


### PR DESCRIPTION
Enable sending emails/sms messages to part of the census, filtering by whether the voters have already casted their vote or not.

# Changes

* Add optional `filter` parameter to `send_auth` api call, when sending messages to the whole census. Valid filter values are ´voted´and ´not_voted´.
* Add tests for elections with email and sms authentication methods. 