### PR TITLE
Support showing PDF in start-screen

### DIFF
--- a/iam/api/management/commands/show_pdf.py
+++ b/iam/api/management/commands/show_pdf.py
@@ -1,0 +1,47 @@
+# This file is part of iam.
+# Copyright (C) 2022  Sequent Tech Inc <legal@sequentech.io>
+
+# iam is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License.
+
+# iam  is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+
+# You should have received a copy of the GNU Affero General Public License
+# along with iam.  If not, see <http://www.gnu.org/licenses/>.
+
+from django.core.management.base import BaseCommand
+from api.models import AuthEvent
+
+class Command(BaseCommand):
+    help = 'Enable/Disable showing a PDF after login for an election'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'election-id',
+            help='Election id',
+            nargs=1,
+            type=str)
+
+        parser.add_argument(
+            '--show-pdf',
+            help=(
+                'Enable showing the PDF'
+            ),
+            action="store_true",
+            default=False
+        )
+
+    def handle(self, *args, **kwargs):
+        election_id = kwargs["election-id"][0]
+        show_pdf = kwargs["show_pdf"]
+
+        auth_event = AuthEvent.objects.get(pk=election_id)
+        current_value = auth_event.auth_method_config.get("show_pdf", False)
+        print("Current show_pdf value for election: ", current_value)
+        print("New show_pdf value for election: ", show_pdf)
+        auth_event.auth_method_config["show_pdf"] = show_pdf
+        auth_event.save()

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -601,14 +601,14 @@ class Authenticate(View):
         try:
             e = get_object_or_404(
                 AuthEvent,
-                pk=pk,
-                status__in=[
-                    AuthEvent.NOT_STARTED,
-                    AuthEvent.STARTED,
-                    AuthEvent.RESUMED
-                ]
+                pk=pk
             )
         except:
+            return json_response(status=400, error_codename=ErrorCodes.BAD_REQUEST)
+
+        if (e.status != AuthEvent.STARTED and
+            e.status != AuthEvent.RESUMED and
+            e.auth_method_config.get("show_pdf") != True):
             return json_response(status=400, error_codename=ErrorCodes.BAD_REQUEST)
 
         if not hasattr(request.user, 'account'):

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -603,6 +603,7 @@ class Authenticate(View):
                 AuthEvent,
                 pk=pk,
                 status__in=[
+                    AuthEvent.NOT_STARTED,
                     AuthEvent.STARTED,
                     AuthEvent.RESUMED
                 ]

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -629,6 +629,7 @@ class Authenticate(View):
                 event=user.userdata.event,
                 metadata=dict())
             action.save()
+            data["show-pdf"] = e.auth_method_config.get("show_pdf", False)
 
             return json_response(data)
         else:


### PR DESCRIPTION
# Changes
* Add command to enable showing PDF on start screen.
* Modify authentication method to enable login in regardless of the election state if showing the PDF is enabled for the election, also returning a variable `show_pdf` to the client.