### PR TITLE
Fix bug on fixed-codes

### DIFF
--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -1888,13 +1888,9 @@ class TestRegisterAndAuthenticateEmail(TestCase):
         created_code = ae_codes[0]
 
         # send new auth message
-        correct_tpl = { "subject": "Vote", "msg": "This is an example __CODE__ and __URL__", "user-ids": [userdata.id] }
-        c = JClient()
-        response = c.authenticate(self.aeid, test_data.auth_email_default)
-        self.assertEqual(response.status_code, 200)
         response = c.post('/api/auth-event/%d/census/send_auth/' % self.aeid, correct_tpl)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(MsgLog.objects.count(), 1)
+        self.assertEqual(MsgLog.objects.count(), 2)
 
         # check no code was created, existing code was used
         from utils import format_code

--- a/iam/utils.py
+++ b/iam/utils.py
@@ -663,11 +663,13 @@ def send_code(
     is_fixed_code = type(auth_config) is dict and auth_config.get('fixed-code')
     if is_fixed_code and not code:
         from authmethods.models import Code
-        code = Code.objects.filter(
+        last_code = Code.objects.filter(
             user=user.userdata,
             auth_event_id=user.userdata.event.id,
             is_enabled=True
-        ).order_by('created').last().code
+        ).order_by('created').last()
+        if last_code:
+            code = last_code.code
 
     if not code:
         code = generate_code(user.userdata).code


### PR DESCRIPTION
For elections using the `fixed-code` feature, trying to send the first authentication message would fail if no code was already present. This fixes it and modifies the test to check it works.