### PR TITLE
bugfix: show pdf not working as expected

### DIFF
--- a/iam/api/management/commands/show_pdf.py
+++ b/iam/api/management/commands/show_pdf.py
@@ -43,5 +43,5 @@ class Command(BaseCommand):
         current_value = auth_event.auth_method_config.get("show_pdf", False)
         print("Current show_pdf value for election: ", current_value)
         print("New show_pdf value for election: ", show_pdf)
-        auth_event.auth_method_config["show_pdf"] = show_pdf
+        auth_event.auth_method_config["config"]["show_pdf"] = show_pdf
         auth_event.save()

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -629,7 +629,7 @@ class Authenticate(View):
                 event=user.userdata.event,
                 metadata=dict())
             action.save()
-            data["show-pdf"] = e.auth_method_config.get("show_pdf", False)
+            data["show-pdf"] = e.auth_method_config.get("config", dict()).get("show_pdf", False)
 
             return json_response(data)
         else:


### PR DESCRIPTION
the show_pdf will be in `auth_method_config['config']` and not in a `auth_method_config`.