### PR TITLE
Election IDs automation

### DIFF
--- a/iam/api/urls.py
+++ b/iam/api/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^acl/mine/$', views.aclmine, name='aclmine'),
 
     url(r'^auth-event/$', views.authevent, name='authevent'),
+    url(r'^auth-event/highest/$', views.get_highest_authevent, name='authevent'),
     url(r'^auth-event/(?P<pk>\d+)/$', views.authevent, name='authevent'),
     url(r'^auth-event/(?P<pk>\d+)/edit-children-parent/$', views.edit_children_parent, name='edit-children-parent'),
     url(r'^auth-event/(?P<pk>\d+)/allow-tally/$', views.allow_tally, name='allow-tally'),

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3201,7 +3201,7 @@ allow_tally = login_required(AllowTallyView.as_view())
 
 
 class GetHighestAutheventView(View):
-    def get(self, request, pk):
+    def get(self, request):
         permission_required(request.user, 'ACL', 'view')
         try:
             highest_pk = AuthEvent.ojects.latest('pk').pk

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3198,3 +3198,17 @@ class AllowTallyView(View):
 
         return json_response()
 allow_tally = login_required(AllowTallyView.as_view())
+
+
+class GetHighestAutheventView(View):
+    def get(self, request, pk):
+        permission_required(request.user, 'ACL', 'view')
+        try:
+            highest_pk = AuthEvent.ojects.latest('pk').pk
+        except AuthEvent.DoesNotExist:
+            highest_pk = 0
+
+        return json_response(dict(
+            highest_pk=highest_pk
+        ))
+get_highest_authevent = login_required(GetHighestAutheventView.as_view())

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3204,7 +3204,7 @@ class GetHighestAutheventView(View):
     def get(self, request):
         permission_required(request.user, 'ACL', 'view')
         try:
-            highest_pk = AuthEvent.ojects.latest('pk').pk
+            highest_pk = AuthEvent.objects.latest('pk').pk
         except AuthEvent.DoesNotExist:
             highest_pk = 0
 

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3209,6 +3209,6 @@ class GetHighestAutheventView(View):
             highest_pk = 0
 
         return json_response(dict(
-            highest_pk=highest_pk
+            highest_id=highest_pk
         ))
 get_highest_authevent = login_required(GetHighestAutheventView.as_view())

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3206,7 +3206,7 @@ class GetHighestAutheventView(View):
         try:
             highest_pk = AuthEvent.objects.latest('pk').pk
         except AuthEvent.DoesNotExist:
-            highest_pk = 0
+            highest_pk = 1
 
         return json_response(dict(
             highest_id=highest_pk


### PR DESCRIPTION
Automate filling in election IDs. If the election ID in the Election JSON is negative, replace it with new Election IDs.

# Changes
* Add endpoint that returns the highest existing election ID.