### PR TITLE
Election IDs automation (#259)

### DIFF
--- a/iam/api/urls.py
+++ b/iam/api/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^acl/mine/$', views.aclmine, name='aclmine'),
 
     url(r'^auth-event/$', views.authevent, name='authevent'),
+    url(r'^auth-event/highest/$', views.get_highest_authevent, name='authevent'),
     url(r'^auth-event/(?P<pk>\d+)/$', views.authevent, name='authevent'),
     url(r'^auth-event/(?P<pk>\d+)/edit-children-parent/$', views.edit_children_parent, name='edit-children-parent'),
     url(r'^auth-event/(?P<pk>\d+)/allow-tally/$', views.allow_tally, name='allow-tally'),

--- a/iam/api/views.py
+++ b/iam/api/views.py
@@ -3198,3 +3198,17 @@ class AllowTallyView(View):
 
         return json_response()
 allow_tally = login_required(AllowTallyView.as_view())
+
+
+class GetHighestAutheventView(View):
+    def get(self, request):
+        permission_required(request.user, 'ACL', 'view')
+        try:
+            highest_pk = AuthEvent.objects.latest('pk').pk
+        except AuthEvent.DoesNotExist:
+            highest_pk = 1
+
+        return json_response(dict(
+            highest_id=highest_pk
+        ))
+get_highest_authevent = login_required(GetHighestAutheventView.as_view())


### PR DESCRIPTION
Automate filling in election IDs. If the election ID in the Election JSON is negative, replace it with new Election IDs.

# Changes
* Add endpoint that returns the highest existing election ID.