### PR TITLE
adding support for giving away information about children election info through URL params in go-to-url

### DIFF
--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -893,6 +893,31 @@ authmethod_config_email_default = {
         }
 }
 
+authmethod_config_email_go_to_url = {
+        "config": {
+            "subject": "Confirm your email",
+            "msg": "Click __URL__ and put this code __CODE__",
+            "authentication-action": {
+                "mode": "go-to-url",
+                "mode-config": {"url": "https://example.com/path/to/somewhere/"}
+            }
+        },
+        "pipeline": {
+            'give_perms': [
+                {'object_type': 'UserData', 'perms': ['edit',], 'object_id': 'UserDataId' },
+                {'object_type': 'AuthEvent', 'perms': ['vote',], 'object_id': 'AuthEventId' }
+            ],
+            "register-pipeline": [
+                ["check_whitelisted", {"field": "ip"}],
+                ["check_blacklisted", {"field": "ip"}],
+                ["check_total_max", {"field": "ip", "max": pipe_total_max_ip}],
+            ],
+            "authenticate-pipeline": [
+                #['check_total_connection', {'times': pipe_times }],
+            ]
+        }
+}
+
 authmethod_config_sms_default = {
         "config": {
             "msg": "Enter in __URL__ and put this code __CODE__",

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -6543,7 +6543,7 @@ class ApiTestGoToUrlAuthenticate(TestCase):
     def setUp(self):
         self.auth_event = AuthEvent(
             auth_method='email',
-            auth_method_config=test_data.authmethod_config_email_go_to_url,
+            auth_method_config=copy.deepcopy(test_data.authmethod_config_email_go_to_url),
             extra_fields=[],
             status='started',
             census='open')
@@ -6591,7 +6591,11 @@ class ApiTestGoToUrlAuthenticate(TestCase):
         Test that the user gets a return url after successful login, replacing
         also __VOTE_CHILDREN_INFO__ in the url template
         '''
-        self.auth_event.auth_method_config['config']['authentication-action']['mode-config']['url'] += "?children=__VOTE_CHILDREN_INFO__"
+        self.auth_event.auth_method_config['config']['authentication-action']['mode-config']['url'] = (
+            test_data.authmethod_config_email_go_to_url['config']['authentication-action']['mode-config']['url'] +
+            "?children=__VOTE_CHILDREN_INFO__"
+        )
+        self.auth_event.save()
         client = JClient()
         user_data = dict(
             email='foo@bar.com',

--- a/iam/api/tests.py
+++ b/iam/api/tests.py
@@ -6534,3 +6534,78 @@ class TestOtl(TestCase):
             }
         )
         self.assertEqual(response.status_code, 200)
+
+
+class ApiTestGoToUrlAuthenticate(TestCase):
+    def setUpTestData():
+        flush_db_load_fixture()
+
+    def setUp(self):
+        self.auth_event = AuthEvent(
+            auth_method='email',
+            auth_method_config=test_data.authmethod_config_email_go_to_url,
+            extra_fields=[],
+            status='started',
+            census='open')
+        self.auth_event.save()
+
+        self.user = User(
+            username='foo',
+            email='foo@bar.com')
+        self.user.set_password('qwerty')
+        self.user.save()
+        self.user.userdata.event = self.auth_event
+        self.user.userdata.save()
+
+        code = Code(
+            user=self.user.userdata,
+            code='ERGERG',
+            auth_event_id=self.auth_event.id)
+        code.save()
+
+        acl = ACL(
+            user=self.user.userdata,
+            object_type='AuthEvent',
+            perm='vote',
+            object_id=self.auth_event.id)
+        acl.save()
+
+    def test_go_to_url_login(self):
+        '''
+        Test that the user gets a return url after successful login
+        '''
+        client = JClient()
+        user_data = dict(
+            email='foo@bar.com',
+            code='ERGERG'
+        )
+        url_auth = '/api/auth-event/%d/authenticate/' % self.auth_event.id
+        response = client.post(url_auth, user_data)
+        self.assertEqual(response.status_code, 200)
+        response_data = parse_json_response(response)
+        redirect_url = test_data.authmethod_config_email_go_to_url['config']['authentication-action']['mode-config']['url']
+        self.assertEqual(response_data['redirect-to-url'], redirect_url)
+
+    def test_go_to_url_login_template(self):
+        '''
+        Test that the user gets a return url after successful login, replacing
+        also __VOTE_CHILDREN_INFO__ in the url template
+        '''
+        self.auth_event.auth_method_config['config']['authentication-action']['mode-config']['url'] += "?children=__VOTE_CHILDREN_INFO__"
+        client = JClient()
+        user_data = dict(
+            email='foo@bar.com',
+            code='ERGERG'
+        )
+        url_auth = '/api/auth-event/%d/authenticate/' % self.auth_event.id
+        response = client.post(url_auth, user_data)
+        self.assertEqual(response.status_code, 200)
+        response_data = parse_json_response(response)
+
+        # Note '%5B%5D' is urlencoded for '[]', which is what is expected since
+        # this is not a parent-children election
+        redirect_url = (
+            test_data.authmethod_config_email_go_to_url['config']['authentication-action']['mode-config']['url'] +
+            "?children=%5B%5D"
+        )
+        self.assertEqual(response_data['redirect-to-url'], redirect_url)

--- a/iam/authmethods/utils.py
+++ b/iam/authmethods/utils.py
@@ -1659,7 +1659,7 @@ def get_redirect_to_url(auth_event, data):
         ]
 
     # encode to json, then url encode it for safety too
-    vote_children_info = urllib.quote(json.dumps(vote_children_info))
+    vote_children_info = urllib.parse.quote(json.dumps(vote_children_info))
 
     url = template_replace_data(
         auth_action['mode-config']['url'],

--- a/iam/authmethods/utils.py
+++ b/iam/authmethods/utils.py
@@ -19,6 +19,7 @@ import re
 import os
 import binascii
 import logging
+import urllib
 from datetime import timedelta, datetime
 from django.conf import settings
 from django.contrib.auth.models import User, AnonymousUser
@@ -40,7 +41,8 @@ from utils import (
     stack_trace_str,
     generate_code,
     send_codes,
-    get_or_create_code
+    get_or_create_code,
+    template_replace_data
 )
 from pipelines.base import execute_pipeline, PipeReturnvalue
 
@@ -1625,7 +1627,7 @@ def return_auth_data(logger_name, req_json, request, user, auth_event=None):
     # add redirection
     auth_action = auth_event.auth_method_config['config']['authentication-action']
     if auth_action['mode'] == 'go-to-url':
-        data['redirect-to-url'] = auth_action['mode-config']['url']
+        data['redirect-to-url'] = get_redirect_to_url(auth_event, data)
 
     LOGGER.debug(\
         "%s.authenticate success\n"\
@@ -1635,6 +1637,35 @@ def return_auth_data(logger_name, req_json, request, user, auth_event=None):
         "Stack trace: \n%s",\
         logger_name, data, auth_event, req_json, stack_trace_str())
     return data
+
+def get_redirect_to_url(auth_event, data):
+    '''
+    Return the redirect-to-url, with templated vars replaced
+    '''
+
+    auth_action = auth_event.auth_method_config['config']['authentication-action']
+    if auth_event.children_election_info is None:
+        vote_children_info = []
+    else:
+        def map_child_info(child_info):
+            mapped = child_info.copy()
+            mapped['can-vote'] = (mapped['vote-permission-token'] is not None)
+            del mapped['vote-permission-token']
+            return mapped
+
+        vote_children_info = [
+            map_child_info(child_event_info)
+            for child_event_info in data['vote-children-info']
+        ]
+
+    # encode to json, then url encode it for safety too
+    vote_children_info = urllib.quote(json.dumps(vote_children_info))
+
+    url = template_replace_data(
+        auth_action['mode-config']['url'],
+        dict(vote_children_info=vote_children_info)
+    )
+    return url
 
 def verify_num_successful_logins(auth_event, logger_name, user, req_json):
     '''


### PR DESCRIPTION
Parent tracking issue: https://github.com/sequentech/meta/issues/61

# New feature

Allow to configure a parameterized/templated url in the go-to-url after a voter logins, where one of the possible template variables is the list of children election ids in which the voter can vote.

## Rationale

Right now there's an (undocumented) manner to let a voter know that they are part of the census and their credentials work without yet allowing them to vote: the `go-to-url` url in iam's `authentication-action`. However, the website in that url doesn't get any information about the voter attributes, and EPI wants to show in which children elections the voter can vote.