### PR TITLE
adding support for giving away information about children election info through URL params in go-to-url 

### DIFF
--- a/iam/api/test_data.py
+++ b/iam/api/test_data.py
@@ -893,6 +893,31 @@ authmethod_config_email_default = {
         }
 }
 
+authmethod_config_email_go_to_url = {
+        "config": {
+            "subject": "Confirm your email",
+            "msg": "Click __URL__ and put this code __CODE__",
+            "authentication-action": {
+                "mode": "go-to-url",
+                "mode-config": {"url": "https://example.com/path/to/somewhere/"}
+            }
+        },
+        "pipeline": {
+            'give_perms': [
+                {'object_type': 'UserData', 'perms': ['edit',], 'object_id': 'UserDataId' },
+                {'object_type': 'AuthEvent', 'perms': ['vote',], 'object_id': 'AuthEventId' }
+            ],
+            "register-pipeline": [
+                ["check_whitelisted", {"field": "ip"}],
+                ["check_blacklisted", {"field": "ip"}],
+                ["check_total_max", {"field": "ip", "max": pipe_total_max_ip}],
+            ],
+            "authenticate-pipeline": [
+                #['check_total_connection', {'times': pipe_times }],
+            ]
+        }
+}
+
 authmethod_config_sms_default = {
         "config": {
             "msg": "Enter in __URL__ and put this code __CODE__",


### PR DESCRIPTION
Parent tracking issue: https://github.com/sequentech/meta/issues/61

# New feature

Allow to configure a parameterized/templated url in the go-to-url after a voter logins, where one of the possible template variables is the list of children election ids in which the voter can vote.

## Rationale

Right now there's an (undocumented) manner to let a voter know that they are part of the census and their credentials work without yet allowing them to vote: the `go-to-url` url in iam's `authentication-action`. However, the website in that url doesn't get any information about the voter attributes, and EPI wants to show in which children elections the voter can vote.