### PR TITLE
Fix send_codes for alt auth methods

### DIFF
--- a/iam/authmethods/m_email_otp.py
+++ b/iam/authmethods/m_email_otp.py
@@ -833,7 +833,7 @@ class EmailOtp:
         # if otp_field_code is not None then post_verify_fields_on_auth already
         # disabled the user code
         if otp_field_code is None:
-            disable_previous_user_codes(user)
+            disable_previous_user_codes(user, auth_event)
 
         if not constant_time_compare(req.get('code').upper(), code.code):
             msg += f"code mismatch for user `{user.userdata}`: [dbcode = `{code.code}`] != [requested code = `{req.get('code').upper()}`]\n"

--- a/iam/authmethods/m_sms_otp.py
+++ b/iam/authmethods/m_sms_otp.py
@@ -820,7 +820,7 @@ class SmsOtp:
         # if otp_field_code is not None then post_verify_fields_on_auth already
         # disabled the user code
         if otp_field_code is None:
-            disable_previous_user_codes(user)
+            disable_previous_user_codes(user, auth_event)
 
         if not constant_time_compare(req.get('code').upper(), code.code):
             msg += f"code mismatch for user `{user.userdata}`: [dbcode = `{code.code}`] != [requested code = `{req.get('code').upper()}`]\n"

--- a/iam/authmethods/utils.py
+++ b/iam/authmethods/utils.py
@@ -1435,7 +1435,13 @@ def resend_auth_code(
         args=[
             [user.id,],
             get_client_ip(request)
-        ]
+        ],
+        # since the auth_event might have been patched, we need to pass the
+        # potentially patched auth_method and config
+        kwargs={
+            "auth_method": auth_event.auth_method,
+            "config": auth_event.auth_method_config.get('config')
+        }
     )
     LOGGER.info(
         f"{logger_name}.resend_auth_code.\n"\

--- a/iam/authmethods/utils.py
+++ b/iam/authmethods/utils.py
@@ -938,7 +938,7 @@ def get_user_code(user, timeout_seconds=None):
 
 def disable_previous_user_codes(user, auth_event):
     # do not disable previous codes if using fixed codes
-    if auth_event.auth_method_config['config']['fixed-code']:
+    if auth_event.auth_method_config.get('config', {}).get('fixed-code', False):
         return
     Code\
         .objects\

--- a/iam/authmethods/utils.py
+++ b/iam/authmethods/utils.py
@@ -936,7 +936,10 @@ def get_user_code(user, timeout_seconds=None):
         .order_by('-created')\
         .first()
 
-def disable_previous_user_codes(user):
+def disable_previous_user_codes(user, auth_event):
+    # do not disable previous codes if using fixed codes
+    if auth_event.auth_method_config['config']['fixed-code']:
+        return
     Code\
         .objects\
         .filter(
@@ -1140,7 +1143,7 @@ def post_verify_fields_on_auth(user, req, auth_event, mode="auth"):
 
     # disable the user code if any
     if otp_field_code is not None:
-        disable_previous_user_codes(user)
+        disable_previous_user_codes(user, auth_event)
 
     return otp_field_code
 

--- a/iam/utils.py
+++ b/iam/utils.py
@@ -345,7 +345,7 @@ def verify_admin_generated_auth_code(
         )
         return False, None
 
-    disable_previous_user_codes(user)
+    disable_previous_user_codes(user, auth_event)
 
     if not constant_time_compare(req_data['code'], code.code):  
         LOGGER.error(


### PR DESCRIPTION
Parent issue: https://github.com/sequentech/meta/issues/260

System was sending the wrong message (from the main auth_method instead of from the alt_auth_method because send_code was not given the proper auth_method config.